### PR TITLE
Bundler support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
           "default": "",
           "description": "execution path of rubocop."
         },
+        "ruby.rubocop.useBundler": {
+          "type": "boolean",
+          "default": false,
+          "description": "use `bundle exec rubocop` (rather than executePath)"
+        },
         "ruby.rubocop.configFilePath": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -62,11 +62,6 @@
           "default": "",
           "description": "execution path of rubocop."
         },
-        "ruby.rubocop.useBundler": {
-          "type": "boolean",
-          "default": false,
-          "description": "use `bundle exec rubocop` (rather than executePath)"
-        },
         "ruby.rubocop.configFilePath": {
           "type": "string",
           "default": "",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,87 @@
+import * as vs from 'vscode';
+import * as fs from 'fs';
+import * as cp from 'child_process';
+import * as path from 'path';
+import Rubocop from './rubocop';
+
+export interface RubocopConfig {
+    command: string;
+    onSave: boolean;
+    configFilePath: string;
+    executeRubocop: (
+        args: string[],
+        opts: cp.ExecFileOptions,
+        cb: (err: Error, stdout: string, stderr: string) => void,
+        ) => cp.ChildProcess;
+}
+
+export const onDidChangeConfiguration: (rubocop: Rubocop) => () => void  = (rubocop) => {
+  return () => rubocop.config = getConfig();
+};
+
+/**
+ * Read the workspace configuration for 'ruby.rubocop' and return a RubocopConfig.
+ *
+ * @todo Refactor Rubocop to use vscode.workspace.onDidChangeConfiguration
+ *   rather than running Rubocop.resetConfig every time the Rubocop binary is executed
+ */
+export const getConfig: () => RubocopConfig = () => {
+  const cmd = (process.platform === 'win32') ? 'rubocop.bat' : 'rubocop';
+  const conf = vs.workspace.getConfiguration('ruby.rubocop');
+  let executeRubocop;
+  let command;
+  let path = conf.get('executePath', '');
+
+  // if executePath is present, use it.
+  if (path.length !== 0) {
+      console.log('Using executePath');
+      command = path + cmd;
+      executeRubocop = (args, options, callback) => cp.execFile(command, args, options, callback);
+  } else if (detectBundledRubocop()) {
+      console.log('Using bundler');
+      command = `bundle exec ${cmd}`;
+      executeRubocop = (args, options, callback) => cp.exec(command + ` ${args.join(' ')}`, options, callback);
+  } else {
+      path = autodetectExecutePath(cmd);
+      if (0 === path.length) {
+        vs.window.showWarningMessage('execute path is empty! please check ruby.rubocop.executePath');
+      }
+      command = path + cmd;
+      executeRubocop = (args, options, callback) => cp.execFile(command, args, options, callback);
+  }
+  return {
+      executeRubocop,
+      command,
+      configFilePath: conf.get('configFilePath', ''),
+      onSave: conf.get('onSave', true),
+  };
+};
+
+const detectBundledRubocop: () => boolean = () => {
+    try {
+        cp.execSync('bundle show rubocop', {cwd: vs.workspace.rootPath});
+        console.log('bundled rubocop found');
+        return true;
+    } catch (e) {
+        console.log(`bundled rubocop not found -${e}`);
+        return false;
+    }
+};
+
+const autodetectExecutePath: (cmd: string) => string = () => {
+    const key: string = 'PATH';
+    let paths = process.env[key];
+    if (!paths) {
+        return '';
+    }
+
+    let pathparts = paths.split(path.delimiter);
+    for (let i = 0; i < pathparts.length; i++) {
+        let binpath = path.join(pathparts[i], this.command);
+        if (fs.existsSync(binpath)) {
+            return pathparts[i] + path.sep;
+        }
+    }
+
+    return '';
+};

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -21,9 +21,7 @@ export const onDidChangeConfiguration: (rubocop: Rubocop) => () => void  = (rubo
 
 /**
  * Read the workspace configuration for 'ruby.rubocop' and return a RubocopConfig.
- *
- * @todo Refactor Rubocop to use vscode.workspace.onDidChangeConfiguration
- *   rather than running Rubocop.resetConfig every time the Rubocop binary is executed
+ * @return {RubocopConfig} config object
  */
 export const getConfig: () => RubocopConfig = () => {
   const cmd = (process.platform === 'win32') ? 'rubocop.bat' : 'rubocop';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 
 import * as vscode from 'vscode';
 import Rubocop from './rubocop';
+import { onDidChangeConfiguration } from './configuration';
 
 // entry point of extension
 export function activate(context: vscode.ExtensionContext): void {
@@ -32,6 +33,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(disposable);
 
     const ws = vscode.workspace;
+
+    ws.onDidChangeConfiguration(onDidChangeConfiguration(rubocop));
 
     ws.textDocuments.forEach((e: vscode.TextDocument) => {
         rubocop.execute(e);

--- a/src/rubocop.ts
+++ b/src/rubocop.ts
@@ -4,54 +4,33 @@ import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-
-// this is never explicitly used anywhere- maybe implicitly used by vscode?
-interface RubocopConfig {
-    executePath: string;
-    configFilePath: string;
-    options: string[];
-    useBundler: boolean;
-}
+import { getConfig, RubocopConfig } from './configuration';
 
 function isFileUri(uri: vscode.Uri): boolean {
     return uri.scheme === 'file';
 }
 
 export default class Rubocop {
+    public config: RubocopConfig;
     private diag: vscode.DiagnosticCollection;
-    private path: string;
-    private command: string;
     private additionalArguments: string[];
-    private configPath: string;
-    private onSave: boolean;
     private executeRubocop: (args: string[],
                              opts: cp.ExecFileOptions,
                              cb: (err: Error, stdout: string, stderr: string) => void) => cp.ChildProcess;
-    private useBundler: boolean;
     private taskQueue: TaskQueue = new TaskQueue();
 
     constructor(
         diagnostics: vscode.DiagnosticCollection,
         additionalArguments: string[] = [],
-        platform: NodeJS.Platform = process.platform,
     ) {
         this.diag = diagnostics;
-        this.command = (platform === 'win32') ? 'rubocop.bat' : 'rubocop';
         this.additionalArguments = additionalArguments;
-        this.resetConfig();
+        this.config = getConfig();
     }
 
     public execute(document: vscode.TextDocument, onComplete?: () => void): void {
         if (document.languageId !== 'ruby' || document.isUntitled || !isFileUri(document.uri)) {
             // git diff has ruby-mode. but it is Untitled file.
-            return;
-        }
-
-        this.resetConfig();
-
-        // todo: deal with this
-        if (!this.useBundler && (!this.path || 0 === this.path.length)) {
-            vscode.window.showWarningMessage('execute path is empty! please check ruby.rubocop.executePath/useBundler config and maybe clean up this error');
             return;
         }
 
@@ -96,7 +75,7 @@ export default class Rubocop {
         const args = this.commandArguments(fileName);
 
         let task = new Task(uri, token => {
-            let process = this.executeRubocop(args, { cwd: currentPath }, (error, stdout, stderr) => {
+            let process = this.config.executeRubocop(args, { cwd: currentPath }, (error, stdout, stderr) => {
                 if (token.isCanceled) {
                     return;
                 }
@@ -112,7 +91,7 @@ export default class Rubocop {
     }
 
     public get isOnSave(): boolean {
-        return this.onSave;
+        return this.config.onSave;
     }
 
     public clear(document: vscode.TextDocument): void {
@@ -127,12 +106,12 @@ export default class Rubocop {
     protected commandArguments(fileName: string): string[] {
         let commandArguments = [fileName, '--format', 'json', '--force-exclusion'];
 
-        if (this.configPath !== '') {
-            if (fs.existsSync(this.configPath)) {
-                const config = ['--config', this.configPath];
+        if (this.config.configFilePath !== '') {
+            if (fs.existsSync(this.config.configFilePath)) {
+                const config = ['--config', this.config.configFilePath];
                 commandArguments = commandArguments.concat(config);
             } else {
-                vscode.window.showWarningMessage(`${this.configPath} file does not exist. Ignoring...`);
+                vscode.window.showWarningMessage(`${this.config.configFilePath} file does not exist. Ignoring...`);
             }
         }
 
@@ -143,7 +122,7 @@ export default class Rubocop {
     private parse(output: string): RubocopOutput | null {
         let rubocop: RubocopOutput;
         if (output.length < 1) {
-            let message = `command ${this.path}${this.command} returns empty output! please check configuration.`;
+            let message = `command ${this.config.command} returns empty output! please check configuration.`;
             vscode.window.showWarningMessage(message);
 
             return null;
@@ -169,50 +148,17 @@ export default class Rubocop {
     private hasError(error: Error, stderr: string): boolean {
         let errorOutput = stderr.toString();
         if (error && (<any>error).code === 'ENOENT') {
-            // todo: handle this error if using bundler
-            vscode.window.showWarningMessage(`${this.path} + ${this.command} is not executable`);
+            vscode.window.showWarningMessage(`${this.config.command} is not executable`);
             return true;
         } else if (error && (<any>error).code === 127) {
             vscode.window.showWarningMessage(stderr);
-            console.log(error.message);
             return true;
         } else if (errorOutput.length > 0) {
             vscode.window.showErrorMessage(stderr);
-            console.log(this.path + this.command);
-            console.log(errorOutput);
             return true;
         }
 
         return false;
-    }
-
-    /**
-     * Read the workspace configuration for 'ruby.rubocop' and set the
-     * `path`, `configPath`, and `onSave` properties.
-     *
-     * @todo Refactor Rubocop to use vscode.workspace.onDidChangeConfiguration
-     *   rather than running Rubocop.resetConfig every time the Rubocop binary is executed
-     */
-    private resetConfig(): void {
-        const conf = vscode.workspace.getConfiguration('ruby.rubocop');
-
-        if (conf.useBundler) {
-            const cmd = ['bundle', 'exec', this.command];
-            console.log(cmd);
-            console.log('Using bundler');
-            this.executeRubocop = (args, options, callback) => cp.exec(cmd.concat(args).join(' '), options, callback);
-        } else {
-            let path = conf.get('executePath', '');
-            // try to autodetect the path (if it's not specified explicitly)
-            if (path.length === 0) {
-                path = this.autodetectExecutePath();
-            }
-            const executeFile = path + this.command;
-            this.executeRubocop = (args, options, callback) => cp.execFile(executeFile, args, options, callback);
-        }
-
-        this.configPath = conf.get('configFilePath', '');
-        this.onSave = conf.get('onSave', true);
     }
 
     private severity(sev: string): vscode.DiagnosticSeverity {
@@ -226,21 +172,4 @@ export default class Rubocop {
         }
     }
 
-    private autodetectExecutePath(): string {
-        const key: string = 'PATH';
-        let paths = process.env[key];
-        if (!paths) {
-            return '';
-        }
-
-        let pathparts = paths.split(path.delimiter);
-        for (let i = 0; i < pathparts.length; i++) {
-            let binpath = path.join(pathparts[i], this.command);
-            if (fs.existsSync(binpath)) {
-                return pathparts[i] + path.sep;
-            }
-        }
-
-        return '';
-    }
 }

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+import { RubocopConfig, getConfig } from '../src/configuration';
+
+describe('RubocopConfig', () => {
+  let config: RubocopConfig;
+
+  // beforeEach(() => {
+  // });
+
+  describe('getConfig', () => {
+    describe('.useBundler', () => {
+      xit('is set to the provided DiagnosticCollection', () => {
+        // expect(instance).to.have.property('diag', diagnostics);
+      });
+    });
+
+    describe('.command', () => {
+      describe('when process.platform is "win32"', () => {
+        beforeEach(() => {
+          // dd
+        });
+
+        xit('is set to "rubocop.bat"', () => {
+          // expect(instance).to.have.property('command', 'rubocop.bat');
+        });
+      });
+
+      describe('when process.platform is not "win32"', () => {
+        beforeEach(() => {
+          // instance = new Rubocop(diagnostics, undefined, 'linux');
+        });
+
+        xit('is set to "rubocop"', () => {
+          // expect(instance).to.have.property('command', 'rubocop');
+        });
+      });
+
+      describe('useBundler', () => {
+        it('is set', () => {
+          // expect(instance).to.have.property('path');
+        });
+      });
+
+      describe('.configPath', () => {
+        it('is set', () => {
+          // expect(instance).to.have.property('configPath');
+        });
+      });
+
+      describe('.onSave', () => {
+        it('is set', () => {
+          // expect(instance).to.have.property('onSave');
+        });
+      });
+    });
+  });
+});

--- a/test/rubocop.test.ts
+++ b/test/rubocop.test.ts
@@ -17,48 +17,5 @@ describe('Rubocop', () => {
         expect(instance).to.have.property('diag', diagnostics);
       });
     });
-
-    describe('.command', () => {
-      describe('when process.platform is "win32"', () => {
-        beforeEach(() => {
-          instance = new Rubocop(diagnostics, undefined, 'win32');
-        });
-
-        it('is set to "rubocop.bat"', () => {
-          expect(instance).to.have.property('command', 'rubocop.bat');
-        });
-      });
-
-      describe('when process.platform is not "win32"', () => {
-        beforeEach(() => {
-          instance = new Rubocop(diagnostics, undefined, 'linux');
-        });
-
-        it('is set to "rubocop"', () => {
-          expect(instance).to.have.property('command', 'rubocop');
-        });
-      });
-    });
-
-    // note: these properties are currently set by Rubocop.resetConfig
-    describe('configuration', () => {
-      describe('.path', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('path');
-        });
-      });
-
-      describe('.configPath', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('configPath');
-        });
-      });
-
-      describe('.onSave', () => {
-        it('is set', () => {
-          expect(instance).to.have.property('onSave');
-        });
-      });
-    });
   });
 });


### PR DESCRIPTION
WIP - resolves #34 
cc @damassi
This PR updates `vscode-ruby-rubocop` to set the `rubocop` command with the following precedence:
1. `executePath` in config
2. Presence of rubocop in Gemfile (using `bundle show rubocop`)
3. Currently-existing autodetect method

It also takes advantage of the (unused?) `RubocopConfig` interface and moves configuration into a separate file, addressing the `todo` to leverage the `onDidChangeConfiguration` vscode hook.

Still needs test updates and clarification on how bundler works in a windows environment.